### PR TITLE
Config file missing isssue fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ riderModule.iml
 # Datasource local storage ignored files
 /dataSources/
 /dataSources.local.xml
+/.vs

--- a/AnimationCancelKeybinding/ModEntry.cs
+++ b/AnimationCancelKeybinding/ModEntry.cs
@@ -26,6 +26,8 @@ internal sealed class ModEntry : Mod
         if (configMenu is null)
             return;
 
+        config = Helper.ReadConfig<ModConfig>();
+        
         // register mod
         configMenu.Register(
             mod: this.ModManifest,


### PR DESCRIPTION
As some people and I noticed, the mod is missing a config.json file, which makes GenericModMenu impossible to configure. So, I fixed this by calling ReadConfig from Helpers to load the settings and create the file if needed.

Ref : https://www.nexusmods.com/stardewvalley/mods/20159?tab=bugs